### PR TITLE
[Feature/EASY-45] neo4j 연동 및 기본 domain, repository, service, controller 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,6 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    implementation 'org.neo4j.driver:neo4j-java-driver:5.6.0'
     implementation 'org.springframework.boot:spring-boot-starter-data-neo4j'
 
     compileOnly 'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,9 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.neo4j.driver:neo4j-java-driver:5.6.0'
+    implementation 'org.springframework.boot:spring-boot-starter-data-neo4j'
+
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/team/molu/edayserver/controller/UserController.java
+++ b/src/main/java/team/molu/edayserver/controller/UserController.java
@@ -1,0 +1,65 @@
+package team.molu.edayserver.controller;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import team.molu.edayserver.domain.Jwt;
+import team.molu.edayserver.domain.Oauth;
+import team.molu.edayserver.domain.User;
+import team.molu.edayserver.service.UserService;
+
+@RestController
+@RequestMapping("api/v1/users")
+@Slf4j
+public class UserController {
+
+    private final UserService userService;
+
+    public UserController(UserService userService) {
+        this.userService = userService;
+    }
+
+    @GetMapping
+    public ResponseEntity<User> getUserByEmail(@RequestParam String email) {
+        User user = userService.findUserByEmail(email);
+        return ResponseEntity.ok(user);
+    }
+
+    @PostMapping
+    public ResponseEntity<Void> createUser(@RequestBody User user) {
+        userService.createUser(user);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @PutMapping
+    public ResponseEntity<Void> updateUser(@RequestBody User user) {
+        boolean updated = userService.updateUser(user);
+        if (updated) {
+            return ResponseEntity.ok().build();
+        }
+        return ResponseEntity.notFound().build();
+    }
+
+    @DeleteMapping
+    public ResponseEntity<Void> deleteUser(@RequestParam String email) {
+        boolean deleted = userService.deleteUserByEmail(email);
+        if (deleted) {
+            return ResponseEntity.noContent().build();
+        } else {
+            return ResponseEntity.notFound().build();
+        }
+    }
+
+    @PostMapping("/oauth")
+    public ResponseEntity<Void> createUserOauth(@RequestParam String email, @RequestBody Oauth oauth) {
+        userService.createUserOauth(oauth, email);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @PostMapping("/jwt")
+    public ResponseEntity<Void> createUserJwt(@RequestParam String email, @RequestBody Jwt jwt) {
+        userService.createUserJwt(jwt, email);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+}

--- a/src/main/java/team/molu/edayserver/domain/Jwt.java
+++ b/src/main/java/team/molu/edayserver/domain/Jwt.java
@@ -1,0 +1,24 @@
+package team.molu.edayserver.domain;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.neo4j.core.schema.Node;
+import org.springframework.data.neo4j.core.schema.Property;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Node("Jwt")
+public class Jwt {
+    @Property
+    private final String refresh;
+
+    @Property
+    private final LocalDateTime ttl;
+
+    @Builder
+    public Jwt(String refresh, LocalDateTime ttl) {
+        this.refresh = refresh;
+        this.ttl = ttl;
+    }
+}

--- a/src/main/java/team/molu/edayserver/domain/Jwt.java
+++ b/src/main/java/team/molu/edayserver/domain/Jwt.java
@@ -2,23 +2,29 @@ package team.molu.edayserver.domain;
 
 import lombok.Builder;
 import lombok.Getter;
-import org.springframework.data.neo4j.core.schema.Node;
-import org.springframework.data.neo4j.core.schema.Property;
+import org.springframework.data.neo4j.core.schema.*;
 
 import java.time.LocalDateTime;
 
 @Getter
 @Node("Jwt")
 public class Jwt {
+    @Id @GeneratedValue
+    private Long id;
+
     @Property
     private final String refresh;
 
     @Property
     private final LocalDateTime ttl;
 
+    @Relationship(type = "HAS_JWT", direction = Relationship.Direction.INCOMING)
+    private User user;
+
     @Builder
-    public Jwt(String refresh, LocalDateTime ttl) {
+    public Jwt(String refresh, LocalDateTime ttl, User user) {
         this.refresh = refresh;
         this.ttl = ttl;
+        this.user = user;
     }
 }

--- a/src/main/java/team/molu/edayserver/domain/Oauth.java
+++ b/src/main/java/team/molu/edayserver/domain/Oauth.java
@@ -1,0 +1,22 @@
+package team.molu.edayserver.domain;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.neo4j.core.schema.Node;
+import org.springframework.data.neo4j.core.schema.Property;
+
+@Getter
+@Node("Oauth")
+public class Oauth {
+    @Property
+    private final String oauthId;
+
+    @Property
+    private final OauthProviderEnum provider;
+
+    @Builder
+    public Oauth(String oauthId, OauthProviderEnum provider) {
+        this.oauthId = oauthId;
+        this.provider = provider;
+    }
+}

--- a/src/main/java/team/molu/edayserver/domain/Oauth.java
+++ b/src/main/java/team/molu/edayserver/domain/Oauth.java
@@ -2,21 +2,27 @@ package team.molu.edayserver.domain;
 
 import lombok.Builder;
 import lombok.Getter;
-import org.springframework.data.neo4j.core.schema.Node;
-import org.springframework.data.neo4j.core.schema.Property;
+import org.springframework.data.neo4j.core.schema.*;
 
 @Getter
 @Node("Oauth")
 public class Oauth {
+    @Id @GeneratedValue
+    private Long id;
+
     @Property
     private final String oauthId;
 
     @Property
     private final OauthProviderEnum provider;
 
+    @Relationship(type = "HAS_OAUTH", direction = Relationship.Direction.INCOMING)
+    private User user;
+
     @Builder
-    public Oauth(String oauthId, OauthProviderEnum provider) {
+    public Oauth(String oauthId, OauthProviderEnum provider, User user) {
         this.oauthId = oauthId;
         this.provider = provider;
+        this.user = user;
     }
 }

--- a/src/main/java/team/molu/edayserver/domain/OauthProviderEnum.java
+++ b/src/main/java/team/molu/edayserver/domain/OauthProviderEnum.java
@@ -1,0 +1,5 @@
+package team.molu.edayserver.domain;
+
+public enum OauthProviderEnum {
+    GOOGLE
+}

--- a/src/main/java/team/molu/edayserver/domain/OauthProviderEnum.java
+++ b/src/main/java/team/molu/edayserver/domain/OauthProviderEnum.java
@@ -1,5 +1,5 @@
 package team.molu.edayserver.domain;
 
 public enum OauthProviderEnum {
-    GOOGLE
+    GOOGLE, NAVER
 }

--- a/src/main/java/team/molu/edayserver/domain/Role.java
+++ b/src/main/java/team/molu/edayserver/domain/Role.java
@@ -1,0 +1,25 @@
+package team.molu.edayserver.domain;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.neo4j.core.schema.Node;
+import org.springframework.data.neo4j.core.schema.Property;
+import org.springframework.data.neo4j.core.schema.Relationship;
+
+import java.util.List;
+
+@Getter
+@Node("Role")
+public class Role {
+    @Property
+    private final RoleEnum type;
+
+    @Relationship(type = "HAS_ROLE", direction = Relationship.Direction.INCOMING)
+    private final List<User> users;
+
+    @Builder
+    public Role(RoleEnum type, List<User> users) {
+        this.type = type;
+        this.users = users;
+    }
+}

--- a/src/main/java/team/molu/edayserver/domain/Role.java
+++ b/src/main/java/team/molu/edayserver/domain/Role.java
@@ -2,15 +2,16 @@ package team.molu.edayserver.domain;
 
 import lombok.Builder;
 import lombok.Getter;
-import org.springframework.data.neo4j.core.schema.Node;
-import org.springframework.data.neo4j.core.schema.Property;
-import org.springframework.data.neo4j.core.schema.Relationship;
+import org.springframework.data.neo4j.core.schema.*;
 
 import java.util.List;
 
 @Getter
 @Node("Role")
 public class Role {
+    @Id @GeneratedValue
+    private Long id;
+
     @Property
     private final RoleEnum type;
 

--- a/src/main/java/team/molu/edayserver/domain/RoleEnum.java
+++ b/src/main/java/team/molu/edayserver/domain/RoleEnum.java
@@ -1,0 +1,5 @@
+package team.molu.edayserver.domain;
+
+public enum RoleEnum {
+    MEMBER, ADMIN
+}

--- a/src/main/java/team/molu/edayserver/domain/User.java
+++ b/src/main/java/team/molu/edayserver/domain/User.java
@@ -2,13 +2,13 @@ package team.molu.edayserver.domain;
 
 import lombok.Builder;
 import lombok.Getter;
+import lombok.Setter;
 import org.springframework.data.neo4j.core.schema.*;
 
 @Getter
 @Node("User")
 public class User {
-    @Id
-    @GeneratedValue
+    @Id @GeneratedValue
     private final Long id;
 
     @Property

--- a/src/main/java/team/molu/edayserver/domain/User.java
+++ b/src/main/java/team/molu/edayserver/domain/User.java
@@ -1,0 +1,38 @@
+package team.molu.edayserver.domain;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.neo4j.core.schema.*;
+
+@Getter
+@Node("User")
+public class User {
+    @Id
+    @GeneratedValue
+    private final Long id;
+
+    @Property
+    private final String email;
+
+    @Property
+    private final String profileImage;
+
+    @Relationship(type = "HAS_ROLE", direction = Relationship.Direction.OUTGOING)
+    private final Role userRole;
+
+    @Relationship(type = "HAS_OAUTH", direction = Relationship.Direction.OUTGOING)
+    private final Oauth userOauth;
+
+    @Relationship(type = "HAS_JWT", direction = Relationship.Direction.OUTGOING)
+    private final Jwt userJwt;
+
+    @Builder
+    public User(Long id, String email, String profileImage, Role userRole, Oauth userOauth, Jwt userJwt) {
+        this.id = id;
+        this.email = email;
+        this.profileImage = profileImage;
+        this.userRole = userRole;
+        this.userOauth = userOauth;
+        this.userJwt = userJwt;
+    }
+}

--- a/src/main/java/team/molu/edayserver/exception/GlobalExceptionHandler.java
+++ b/src/main/java/team/molu/edayserver/exception/GlobalExceptionHandler.java
@@ -1,0 +1,15 @@
+package team.molu.edayserver.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@ControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(UserNotFoundException.class)
+    public ResponseEntity<String> handleUserNotFoundException(UserNotFoundException ex) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ex.getMessage());
+    }
+}

--- a/src/main/java/team/molu/edayserver/exception/UserNotFoundException.java
+++ b/src/main/java/team/molu/edayserver/exception/UserNotFoundException.java
@@ -1,0 +1,7 @@
+package team.molu.edayserver.exception;
+
+public class UserNotFoundException extends RuntimeException {
+    public UserNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/team/molu/edayserver/repository/JwtRepository.java
+++ b/src/main/java/team/molu/edayserver/repository/JwtRepository.java
@@ -1,0 +1,11 @@
+package team.molu.edayserver.repository;
+
+import org.springframework.data.neo4j.repository.ReactiveNeo4jRepository;
+import org.springframework.data.neo4j.repository.query.Query;
+import reactor.core.publisher.Mono;
+import team.molu.edayserver.domain.Jwt;
+
+public interface JwtRepository extends ReactiveNeo4jRepository<Jwt, Long> {
+    @Query("MATCH (u:User {email = $email})-[r:HAS_JWT]->(j:Jwt) RETURN j")
+    Mono<Jwt> findJwtByEmail(String email);
+}

--- a/src/main/java/team/molu/edayserver/repository/OauthRepository.java
+++ b/src/main/java/team/molu/edayserver/repository/OauthRepository.java
@@ -1,0 +1,12 @@
+package team.molu.edayserver.repository;
+
+import org.springframework.data.neo4j.repository.ReactiveNeo4jRepository;
+import org.springframework.data.neo4j.repository.query.Query;
+import reactor.core.publisher.Mono;
+import team.molu.edayserver.domain.Oauth;
+import team.molu.edayserver.domain.User;
+
+public interface OauthRepository extends ReactiveNeo4jRepository<Oauth, Long> {
+    @Query("MATCH (u:User {email = $email})-[r:HAS_OAUTH]->(o:Oauth) RETURN o")
+    Mono<Oauth> findOauthByEmail(String email);
+}

--- a/src/main/java/team/molu/edayserver/repository/RoleRepository.java
+++ b/src/main/java/team/molu/edayserver/repository/RoleRepository.java
@@ -1,0 +1,13 @@
+package team.molu.edayserver.repository;
+
+import org.springframework.data.neo4j.repository.ReactiveNeo4jRepository;
+import org.springframework.data.neo4j.repository.query.Query;
+import reactor.core.publisher.Flux;
+import team.molu.edayserver.domain.Role;
+import team.molu.edayserver.domain.RoleEnum;
+
+public interface RoleRepository extends ReactiveNeo4jRepository<Role, Long> {
+    // Role Type과 일치하는 모든 유저를 조회
+    @Query("MATCH (u:User)-[:HAS_ROLE]->(r:Role {type: $roleType}) RETURN u")
+    Flux<Role> findAllUserByRole(RoleEnum roleType);
+}

--- a/src/main/java/team/molu/edayserver/repository/UserRepository.java
+++ b/src/main/java/team/molu/edayserver/repository/UserRepository.java
@@ -1,0 +1,16 @@
+package team.molu.edayserver.repository;
+
+import org.springframework.data.neo4j.repository.ReactiveNeo4jRepository;
+import org.springframework.data.neo4j.repository.query.Query;
+import reactor.core.publisher.Mono;
+import team.molu.edayserver.domain.User;
+
+public interface UserRepository extends ReactiveNeo4jRepository<User, Long> {
+    // email로 사용자 조회
+    @Query("MATCH (u:User) WHERE u.email = $email RETURN u")
+    Mono<User> findUserByEmail(String email);
+
+    // 사용자와 관련된 Role, Oauth, Jwt 함께 조회
+    @Query("MATCH (u:User)-[:HAS_ROLE]->(r:Role), (u)-[:HAS_OAUTH]->(o:Oauth), (u)-[:HAS_JWT]->(j:Jwt) WHERE u.email = $email RETURN u, r, o, j")
+    Mono<User> findUserWithRelationshipsByEmail(String email);
+}

--- a/src/main/java/team/molu/edayserver/service/RoleService.java
+++ b/src/main/java/team/molu/edayserver/service/RoleService.java
@@ -1,0 +1,4 @@
+package team.molu.edayserver.service;
+
+public interface RoleService {
+}

--- a/src/main/java/team/molu/edayserver/service/UserService.java
+++ b/src/main/java/team/molu/edayserver/service/UserService.java
@@ -1,0 +1,86 @@
+package team.molu.edayserver.service;
+
+import team.molu.edayserver.domain.Jwt;
+import team.molu.edayserver.domain.Oauth;
+import team.molu.edayserver.domain.User;
+
+public interface UserService {
+    /**
+     * 주어진 email에 해당하는 사용자 정보를 조회합니다.
+     *
+     * @param email 조회할 사용자 email
+     * @return 사용자 객체, 해당 ID의 사용자가 없으면 null 반환
+     */
+    User findUserByEmail(String email);
+
+    /**
+     * 사용자 정보를 저장합니다.
+     *
+     * @param user 저장할 사용자 객체
+     */
+    void createUser(User user);
+
+    /**
+     * 사용자 정보를 업데이트합니다.
+     *
+     * @param user 수정할 사용자 객체
+     * @return 정상적으로 수정되었다면 true, 아니라면 false 반환
+     */
+    boolean updateUser(User user);
+
+    /**
+     * 사용자를 삭제합니다.
+     *
+     * @param email 삭제할 사용자 Email
+     * @return 정상적으로 삭제되었다면 true, 아니라면 false 반환
+     */
+    boolean deleteUserByEmail(String email);
+
+    /**
+     * 사용자 OAuth를 저장합니다.
+     *
+     * @param oauth 추가할 사용자 관련 oauth
+     * @param email 사용자 Email
+     */
+    void createUserOauth(Oauth oauth, String email);
+
+    /**
+     * 사용자 OAuth를 수정합니다.
+     *
+     * @param oauth 수정할 사용자 관련 oauth
+     * @return 정상적으로 수정되었다면 true, 아니라면 false 반환
+     */
+    boolean updateUserOauth(Oauth oauth, String email);
+
+    /**
+     * 사용자 OAuth를 삭제합니다.
+     *
+     * @param email 삭제할 사용자 email
+     * @return 정상적으로 삭제되었다면 true, 아니라면 false 반환
+     */
+    boolean deleteUserOauthByEmail(String email);
+
+    /**
+     * 사용자 JWT를 저장합니다.
+     *
+     * @param jwt 추가할 사용자 관련 jwt
+     * @param email 사용자 Email
+     */
+    void createUserJwt(Jwt jwt, String email);
+
+    /**
+     * 사용자 JWT를 수정합니다.
+     *
+     * @param jwt 수정할 사용자 관련 jwt
+     * @return 정상적으로 수정되었다면 true, 아니라면 false 반환
+     */
+    boolean updateUserJwt(Jwt jwt, String email);
+
+    /**
+     * 사용자 JWT를 삭제합니다.
+     *
+     * @param email 삭제할 사용자 email
+     * @return 정상적으로 삭제되었다면 true, 아니라면 false 반환
+     */
+    boolean deleteUserJwtByEmail(String email);
+}

--- a/src/main/java/team/molu/edayserver/service/UserServiceNeo4jImpl.java
+++ b/src/main/java/team/molu/edayserver/service/UserServiceNeo4jImpl.java
@@ -1,0 +1,143 @@
+package team.molu.edayserver.service;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+import team.molu.edayserver.domain.Jwt;
+import team.molu.edayserver.domain.Oauth;
+import team.molu.edayserver.domain.User;
+import team.molu.edayserver.exception.UserNotFoundException;
+import team.molu.edayserver.repository.JwtRepository;
+import team.molu.edayserver.repository.OauthRepository;
+import team.molu.edayserver.repository.UserRepository;
+
+@Service
+@Qualifier("neo4j")
+@Slf4j
+public class UserServiceNeo4jImpl implements UserService {
+    private final UserRepository userRepository;
+    private final OauthRepository oauthRepository;
+    private final JwtRepository jwtRepository;
+
+    public UserServiceNeo4jImpl(UserRepository userRepository, OauthRepository oauthRepository, JwtRepository jwtRepository) {
+        this.userRepository = userRepository;
+        this.oauthRepository = oauthRepository;
+        this.jwtRepository = jwtRepository;
+    }
+
+    @Override
+    public User findUserByEmail(String email) {
+        Mono<User> userMono = userRepository.findUserByEmail(email);
+        return userMono.switchIfEmpty(Mono.error(new UserNotFoundException("User not found with email: " + email)))
+                .block();
+    }
+
+    @Override
+    public void createUser(User user) {
+        userRepository.save(user).subscribe();
+    }
+
+    @Override
+    public boolean updateUser(User user) {
+        return Boolean.TRUE.equals(userRepository.findUserByEmail(user.getEmail())
+                .switchIfEmpty(Mono.error(new UserNotFoundException("User not found with email: " + user.getEmail())))
+                .flatMap(existingUser -> {
+                    User updatedUser = User.builder()
+                            .id(existingUser.getId())
+                            .email(existingUser.getEmail())
+                            .profileImage(user.getProfileImage() != null ? user.getProfileImage() : existingUser.getProfileImage())
+                            .userRole(existingUser.getUserRole())
+                            .userOauth(existingUser.getUserOauth())
+                            .userJwt(existingUser.getUserJwt())
+                            .build();
+
+                    log.info("test");
+
+                    return userRepository.save(updatedUser);
+                })
+                .map(savedUser -> true)
+                .onErrorReturn(false)
+                .block());
+    }
+
+    @Override
+    public boolean deleteUserByEmail(String email) {
+        return Boolean.TRUE.equals(userRepository.findUserByEmail(email)
+                .switchIfEmpty(Mono.error(new UserNotFoundException("User not found with email: " + email)))
+                .flatMap(existingUser -> userRepository.delete(existingUser)
+                        .then(Mono.just(true)))
+                .onErrorReturn(false)
+                .block());
+    }
+
+    @Override
+    public void createUserOauth(Oauth oauth, String email) {
+        userRepository.findUserByEmail(email)
+                .switchIfEmpty(Mono.error(new UserNotFoundException("User not found with email: " + email)))
+                .flatMap(user -> {
+                    Oauth newOauth = Oauth.builder()
+                            .oauthId(oauth.getOauthId())
+                            .provider(oauth.getProvider())
+                            .user(user)
+                            .build();
+                    return oauthRepository.save(newOauth);
+                })
+                .block();
+    }
+
+    @Override
+    public boolean updateUserOauth(Oauth oauth, String email) {
+        return Boolean.TRUE.equals(oauthRepository.findOauthByEmail(email)
+                .switchIfEmpty(Mono.error(new IllegalArgumentException("Oauth not found with email: " + email)))
+                .flatMap(existingOauth -> oauthRepository.save(oauth))
+                .map(savedOauth -> true)
+                .onErrorReturn(false)
+                .block());
+    }
+
+    @Override
+    public boolean deleteUserOauthByEmail(String email) {
+        return Boolean.TRUE.equals(oauthRepository.findOauthByEmail(email)
+                .switchIfEmpty(Mono.error(new IllegalArgumentException("Oauth not found with email: " + email)))
+                .flatMap(existingOauth -> oauthRepository.delete(existingOauth)
+                        .then(Mono.just(true)))
+                .onErrorReturn(false)
+                .block());
+    }
+
+    @Override
+    public void createUserJwt(Jwt jwt, String email) {
+        userRepository.findUserByEmail(email)
+                .switchIfEmpty(Mono.error(new UserNotFoundException("User not found with email: " + email)))
+                .flatMap(user -> {
+                    Jwt newJwt = Jwt.builder()
+                            .refresh(jwt.getRefresh())
+                            .ttl(jwt.getTtl())
+                            .user(user)
+                            .build();
+                    return jwtRepository.save(newJwt);
+                })
+                .block();
+    }
+
+    @Override
+    public boolean updateUserJwt(Jwt jwt, String email) {
+        return Boolean.TRUE.equals(jwtRepository.findJwtByEmail(email)
+                .switchIfEmpty(Mono.error(new IllegalArgumentException("Jwt not found with email: " + email)))
+                .flatMap(existingJwt -> jwtRepository.save(jwt))
+                .map(savedJwt -> true)
+                .onErrorReturn(false)
+                .block());
+    }
+
+    @Override
+    public boolean deleteUserJwtByEmail(String email) {
+        return Boolean.TRUE.equals(jwtRepository.findJwtByEmail(email)
+                .switchIfEmpty(Mono.error(new IllegalArgumentException("Jwt not found with email: " + email)))
+                .flatMap(existingJwt -> jwtRepository.delete(existingJwt)
+                        .then(Mono.just(true)))
+                .onErrorReturn(false)
+                .block());
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,4 @@
 spring.application.name=eday-server
+spring.neo4j.uri=${NEO4J_URI}
+spring.neo4j.authentication.username=neo4j
+spring.neo4j.authentication.password=${NEO4J_PW}

--- a/src/test/java/team/molu/edayserver/controller/UserContollerTest.java
+++ b/src/test/java/team/molu/edayserver/controller/UserContollerTest.java
@@ -1,0 +1,156 @@
+package team.molu.edayserver.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import team.molu.edayserver.domain.Jwt;
+import team.molu.edayserver.domain.Oauth;
+import team.molu.edayserver.domain.OauthProviderEnum;
+import team.molu.edayserver.domain.User;
+import team.molu.edayserver.service.UserService;
+
+import java.time.LocalDateTime;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(UserController.class)
+class UserControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private UserService userService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private User user;
+    private Oauth oauth;
+    private Jwt jwt;
+
+    @BeforeEach
+    void setUp() {
+        user = User.builder()
+                .id(1L)
+                .email("test@example.com")
+                .profileImage("profile.jpg")
+                .build();
+
+        oauth = Oauth.builder()
+                .oauthId("oauth123")
+                .provider(OauthProviderEnum.GOOGLE)
+                .user(user)
+                .build();
+
+        jwt = Jwt.builder()
+                .refresh("refresh123")
+                .ttl(LocalDateTime.now())
+                .user(user)
+                .build();
+    }
+
+    @Test
+    void getUserByEmail_shouldReturnUser_whenUserExists() throws Exception {
+        when(userService.findUserByEmail(user.getEmail())).thenReturn(user);
+
+        mockMvc.perform(get("/api/v1/users")
+                        .param("email", user.getEmail()))
+                .andExpect(status().isOk());
+
+        verify(userService, times(1)).findUserByEmail(user.getEmail());
+    }
+
+    @Test
+    void createUser_shouldReturnCreated() throws Exception {
+        doNothing().when(userService).createUser(any(User.class));
+
+        mockMvc.perform(post("/api/v1/users")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(user)))
+                .andExpect(status().isCreated());
+
+        verify(userService, times(1)).createUser(any(User.class));
+    }
+
+    @Test
+    void updateUser_shouldReturnOk_whenUserUpdated() throws Exception {
+        when(userService.updateUser(any(User.class))).thenReturn(true);
+
+        mockMvc.perform(put("/api/v1/users")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(user)))
+                .andExpect(status().isOk());
+
+        verify(userService, times(1)).updateUser(any(User.class));
+    }
+
+    @Test
+    void updateUser_shouldReturnNotFound_whenUserNotUpdated() throws Exception {
+        when(userService.updateUser(any(User.class))).thenReturn(false);
+
+        mockMvc.perform(put("/api/v1/users")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(user)))
+                .andExpect(status().isNotFound());
+
+        verify(userService, times(1)).updateUser(any(User.class));
+    }
+
+    @Test
+    void deleteUser_shouldReturnNoContent_whenUserDeleted() throws Exception {
+        when(userService.deleteUserByEmail(user.getEmail())).thenReturn(true);
+
+        mockMvc.perform(delete("/api/v1/users")
+                        .param("email", user.getEmail()))
+                .andExpect(status().isNoContent());
+
+        verify(userService, times(1)).deleteUserByEmail(user.getEmail());
+    }
+
+    @Test
+    void deleteUser_shouldReturnNotFound_whenUserNotDeleted() throws Exception {
+        when(userService.deleteUserByEmail(user.getEmail())).thenReturn(false);
+
+        mockMvc.perform(delete("/api/v1/users")
+                        .param("email", user.getEmail()))
+                .andExpect(status().isNotFound());
+
+        verify(userService, times(1)).deleteUserByEmail(user.getEmail());
+    }
+
+    @Test
+    void createUserOauth_shouldReturnCreated() throws Exception {
+        doNothing().when(userService).createUserOauth(any(Oauth.class), eq(user.getEmail()));
+
+        mockMvc.perform(post("/api/v1/users/oauth")
+                        .param("email", user.getEmail())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(oauth)))
+                .andExpect(status().isCreated());
+
+        verify(userService, times(1)).createUserOauth(any(Oauth.class), eq(user.getEmail()));
+    }
+
+    @Test
+    void createUserJwt_shouldReturnCreated() throws Exception {
+        doNothing().when(userService).createUserJwt(any(Jwt.class), eq(user.getEmail()));
+
+        mockMvc.perform(post("/api/v1/users/jwt")
+                        .param("email", user.getEmail())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(jwt)))
+                .andExpect(status().isCreated());
+
+        verify(userService, times(1)).createUserJwt(any(Jwt.class), eq(user.getEmail()));
+    }
+}

--- a/src/test/java/team/molu/edayserver/service/UserServiceNeo4jImplTest.java
+++ b/src/test/java/team/molu/edayserver/service/UserServiceNeo4jImplTest.java
@@ -1,0 +1,287 @@
+package team.molu.edayserver.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import reactor.core.publisher.Mono;
+import team.molu.edayserver.domain.Jwt;
+import team.molu.edayserver.domain.Oauth;
+import team.molu.edayserver.domain.OauthProviderEnum;
+import team.molu.edayserver.domain.User;
+import team.molu.edayserver.exception.UserNotFoundException;
+import team.molu.edayserver.repository.JwtRepository;
+import team.molu.edayserver.repository.OauthRepository;
+import team.molu.edayserver.repository.UserRepository;
+
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceNeo4jImplTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private OauthRepository oauthRepository;
+
+    @Mock
+    private JwtRepository jwtRepository;
+
+    @InjectMocks
+    private UserServiceNeo4jImpl userService;
+
+    private User user;
+    private Oauth oauth;
+    private Jwt jwt;
+
+    @BeforeEach
+    void setUp() {
+        user = User.builder()
+                .id(1L)
+                .email("test@example.com")
+                .profileImage("profile.jpg")
+                .build();
+
+        oauth = Oauth.builder()
+                .oauthId("oauth123")
+                .provider(OauthProviderEnum.GOOGLE)
+                .user(user)
+                .build();
+
+        jwt = Jwt.builder()
+                .refresh("refresh123")
+                .ttl(LocalDateTime.now())
+                .user(user)
+                .build();
+    }
+
+    @Test
+    void findUserByEmail_shouldReturnUser_whenUserExists() {
+        when(userRepository.findUserByEmail(user.getEmail())).thenReturn(Mono.just(user));
+
+        User foundUser = userService.findUserByEmail(user.getEmail());
+
+        assertEquals(user, foundUser);
+        verify(userRepository, times(1)).findUserByEmail(user.getEmail());
+    }
+
+    @Test
+    void findUserByEmail_shouldThrowException_whenUserDoesNotExist() {
+        when(userRepository.findUserByEmail(user.getEmail())).thenReturn(Mono.empty());
+
+        assertThrows(UserNotFoundException.class, () -> userService.findUserByEmail(user.getEmail()));
+        verify(userRepository, times(1)).findUserByEmail(user.getEmail());
+    }
+
+    @Test
+    void createUser_shouldSaveUser() {
+        when(userRepository.save(user)).thenReturn(Mono.just(user));
+
+        userService.createUser(user);
+
+        verify(userRepository, times(1)).save(user);
+    }
+
+    @Test
+    void updateUser_shouldUpdateUser_whenUserExists() {
+        User updatedUser = User.builder()
+                .id(user.getId())
+                .email(user.getEmail())
+                .profileImage("updated.jpg")
+                .build();
+
+        when(userRepository.findUserByEmail(user.getEmail())).thenReturn(Mono.just(user));
+        when(userRepository.save(any(User.class))).thenReturn(Mono.just(updatedUser));
+
+        boolean updated = userService.updateUser(updatedUser);
+
+        assertTrue(updated);
+        verify(userRepository, times(1)).findUserByEmail(user.getEmail());
+        verify(userRepository, times(1)).save(any(User.class));
+    }
+
+    @Test
+    void updateUser_shouldReturnFalse_whenUserDoesNotExist() {
+        when(userRepository.findUserByEmail(user.getEmail())).thenReturn(Mono.empty());
+
+        boolean updated = userService.updateUser(user);
+
+        assertFalse(updated);
+        verify(userRepository, times(1)).findUserByEmail(user.getEmail());
+        verify(userRepository, never()).save(any(User.class));
+    }
+
+    @Test
+    void deleteUserByEmail_shouldDeleteUser_whenUserExists() {
+        when(userRepository.findUserByEmail(user.getEmail())).thenReturn(Mono.just(user));
+        when(userRepository.delete(user)).thenReturn(Mono.empty());
+
+        boolean deleted = userService.deleteUserByEmail(user.getEmail());
+
+        assertTrue(deleted);
+        verify(userRepository, times(1)).findUserByEmail(user.getEmail());
+        verify(userRepository, times(1)).delete(user);
+    }
+
+    @Test
+    void deleteUserByEmail_shouldReturnFalse_whenUserDoesNotExist() {
+        when(userRepository.findUserByEmail(user.getEmail())).thenReturn(Mono.empty());
+
+        boolean deleted = userService.deleteUserByEmail(user.getEmail());
+
+        assertFalse(deleted);
+        verify(userRepository, times(1)).findUserByEmail(user.getEmail());
+        verify(userRepository, never()).delete(any(User.class));
+    }
+
+    @Test
+    void createUserOauth_shouldSaveOauth_whenUserExists() {
+        when(userRepository.findUserByEmail(user.getEmail())).thenReturn(Mono.just(user));
+        when(oauthRepository.save(any(Oauth.class))).thenReturn(Mono.just(oauth));
+
+        userService.createUserOauth(oauth, user.getEmail());
+
+        verify(userRepository, times(1)).findUserByEmail(user.getEmail());
+        verify(oauthRepository, times(1)).save(any(Oauth.class));
+    }
+
+    @Test
+    void createUserOauth_shouldThrowException_whenUserDoesNotExist() {
+        when(userRepository.findUserByEmail(user.getEmail())).thenReturn(Mono.empty());
+
+        assertThrows(UserNotFoundException.class, () -> userService.createUserOauth(oauth, user.getEmail()));
+        verify(userRepository, times(1)).findUserByEmail(user.getEmail());
+        verify(oauthRepository, never()).save(any(Oauth.class));
+    }
+
+    @Test
+    void updateUserOauth_shouldUpdateOauth_whenOauthExists() {
+        Oauth updatedOauth = Oauth.builder()
+                .oauthId(oauth.getOauthId())
+                .provider(OauthProviderEnum.NAVER)
+                .user(user)
+                .build();
+
+        when(oauthRepository.findOauthByEmail(user.getEmail())).thenReturn(Mono.just(oauth));
+        when(oauthRepository.save(any(Oauth.class))).thenReturn(Mono.just(updatedOauth));
+
+        boolean updated = userService.updateUserOauth(updatedOauth, user.getEmail());
+
+        assertTrue(updated);
+        verify(oauthRepository, times(1)).findOauthByEmail(user.getEmail());
+        verify(oauthRepository, times(1)).save(any(Oauth.class));
+    }
+
+    @Test
+    void updateUserOauth_shouldReturnFalse_whenOauthDoesNotExist() {
+        when(oauthRepository.findOauthByEmail(user.getEmail())).thenReturn(Mono.empty());
+
+        boolean updated = userService.updateUserOauth(oauth, user.getEmail());
+
+        assertFalse(updated);
+        verify(oauthRepository, times(1)).findOauthByEmail(user.getEmail());
+        verify(oauthRepository, never()).save(any(Oauth.class));
+    }
+
+    @Test
+    void deleteUserOauthByEmail_shouldDeleteOauth_whenOauthExists() {
+        when(oauthRepository.findOauthByEmail(user.getEmail())).thenReturn(Mono.just(oauth));
+        when(oauthRepository.delete(oauth)).thenReturn(Mono.empty());
+
+        boolean deleted = userService.deleteUserOauthByEmail(user.getEmail());
+
+        assertTrue(deleted);
+        verify(oauthRepository, times(1)).findOauthByEmail(user.getEmail());
+        verify(oauthRepository, times(1)).delete(oauth);
+    }
+
+    @Test
+    void deleteUserOauthByEmail_shouldReturnFalse_whenOauthDoesNotExist() {
+        when(oauthRepository.findOauthByEmail(user.getEmail())).thenReturn(Mono.empty());
+
+        boolean deleted = userService.deleteUserOauthByEmail(user.getEmail());
+
+        assertFalse(deleted);
+        verify(oauthRepository, times(1)).findOauthByEmail(user.getEmail());
+        verify(oauthRepository, never()).delete(any(Oauth.class));
+    }
+
+    @Test
+    void createUserJwt_shouldSaveJwt_whenUserExists() {
+        when(userRepository.findUserByEmail(user.getEmail())).thenReturn(Mono.just(user));
+        when(jwtRepository.save(any(Jwt.class))).thenReturn(Mono.just(jwt));
+
+        userService.createUserJwt(jwt, user.getEmail());
+
+        verify(userRepository, times(1)).findUserByEmail(user.getEmail());
+        verify(jwtRepository, times(1)).save(any(Jwt.class));
+    }
+
+    @Test
+    void createUserJwt_shouldThrowException_whenUserDoesNotExist() {
+        when(userRepository.findUserByEmail(user.getEmail())).thenReturn(Mono.empty());
+
+        assertThrows(UserNotFoundException.class, () -> userService.createUserJwt(jwt, user.getEmail()));
+        verify(userRepository, times(1)).findUserByEmail(user.getEmail());
+        verify(jwtRepository, never()).save(any(Jwt.class));
+    }
+
+    @Test
+    void updateUserJwt_shouldUpdateJwt_whenJwtExists() {
+        Jwt updatedJwt = Jwt.builder()
+                .refresh(jwt.getRefresh())
+                .ttl(LocalDateTime.of(2024, 6, 10, 12,0))
+                .user(user)
+                .build();
+
+        when(jwtRepository.findJwtByEmail(user.getEmail())).thenReturn(Mono.just(jwt));
+        when(jwtRepository.save(any(Jwt.class))).thenReturn(Mono.just(updatedJwt));
+
+        boolean updated = userService.updateUserJwt(updatedJwt, user.getEmail());
+
+        assertTrue(updated);
+        verify(jwtRepository, times(1)).findJwtByEmail(user.getEmail());
+        verify(jwtRepository, times(1)).save(any(Jwt.class));
+    }
+
+    @Test
+    void updateUserJwt_shouldReturnFalse_whenJwtDoesNotExist() {
+        when(jwtRepository.findJwtByEmail(user.getEmail())).thenReturn(Mono.empty());
+
+        boolean updated = userService.updateUserJwt(jwt, user.getEmail());
+
+        assertFalse(updated);
+        verify(jwtRepository, times(1)).findJwtByEmail(user.getEmail());
+        verify(jwtRepository, never()).save(any(Jwt.class));
+    }
+
+    @Test
+    void deleteUserJwtByEmail_shouldDeleteJwt_whenJwtExists() {
+        when(jwtRepository.findJwtByEmail(user.getEmail())).thenReturn(Mono.just(jwt));
+        when(jwtRepository.delete(jwt)).thenReturn(Mono.empty());
+
+        boolean deleted = userService.deleteUserJwtByEmail(user.getEmail());
+
+        assertTrue(deleted);
+        verify(jwtRepository, times(1)).findJwtByEmail(user.getEmail());
+        verify(jwtRepository, times(1)).delete(jwt);
+    }
+
+    @Test
+    void deleteUserJwtByEmail_shouldReturnFalse_whenJwtDoesNotExist() {
+        when(jwtRepository.findJwtByEmail(user.getEmail())).thenReturn(Mono.empty());
+
+        boolean deleted = userService.deleteUserJwtByEmail(user.getEmail());
+
+        assertFalse(deleted);
+        verify(jwtRepository, times(1)).findJwtByEmail(user.getEmail());
+        verify(jwtRepository, never()).delete(any(Jwt.class));
+    }
+}


### PR DESCRIPTION
## 한 일
1. neo4j AuraDB 연동
2. UserNotFoundException 클래스 추가 및 GlobalExceptionHandler 추가
3. User, Role, Oauth, Jwt 엔티티 추가
  - Setter 지양, Builder 패턴 사용, Spring Data Neo4J 사용
4. User, Role, Oauth, Jwt 레포지토리 추가
  - Spring Data Neo4J 사용
5. UserService 인터페이스 설계 및 UserServiceNeo4jImpl 구현
6. UserController 추가 및 API 동작, Neo4J AuraDB CRUD 연산 동작 확인
7. 테스트 코드 추가 및 단위 테스트 진행

## 할 일
1. Neo4J에서 id(elementId)의 직접적인 활용은 Deprecated 되었음. 따라서 id와 관련된 코드 수정이 필요.
2. 데이터 아키텍쳐에 명시되어있는 나머지 도메인(노드) 및 레포지토리 추가 필요
3. 필요 시 UserServiceH2Impl 구현

## 장애물
1. 서비스 또는 컨트롤러(API) 명세 문서가 없으므로, UserService 인터페이스 구현이 완벽하지 않음. 추가 회의 필요.