### PR TITLE
[EASY-64] feat: 문자열 task 검색 기능 추가

### DIFF
--- a/src/main/java/team/molu/edayserver/controller/TaskController.java
+++ b/src/main/java/team/molu/edayserver/controller/TaskController.java
@@ -104,4 +104,10 @@ public class TaskController {
         TasksDto.TaskUnarchiveResponse taskUnarchiveResponse = taskService.unarchiveTask(taskDto);
         return ResponseEntity.ok(taskUnarchiveResponse);
     }
+
+    @PostMapping("/search")
+    public ResponseEntity<TasksDto.SearchTasksResponse> searchTaskByName(@RequestBody TasksDto.TaskSearchByNameRequest taskDto) {
+        TasksDto.SearchTasksResponse searchTasksResponse = taskService.searchTasksByName(taskDto);
+        return ResponseEntity.ok(searchTasksResponse);
+    }
 }

--- a/src/main/java/team/molu/edayserver/dto/TasksDto.java
+++ b/src/main/java/team/molu/edayserver/dto/TasksDto.java
@@ -143,4 +143,11 @@ public class TasksDto {
         private String name;
         private Integer order;
     }
+
+    @Getter
+    @Builder
+    public static class TaskSearchByNameRequest {
+        private String text;
+        private String type;
+    }
 }

--- a/src/main/java/team/molu/edayserver/repository/TaskRepository.java
+++ b/src/main/java/team/molu/edayserver/repository/TaskRepository.java
@@ -219,4 +219,9 @@ public interface TaskRepository extends ReactiveNeo4jRepository<Task, String> {
             "CREATE (p)-[:BELONGS_TO]->(t) " +
             "RETURN toInteger(CASE WHEN t IS NOT NULL THEN size(cs) + 1 ELSE 0 END) AS archivedNodes, p.id AS parentId, t.id AS taskId")
     Mono<TasksDto.TaskUnarchiveResponse> unarchiveTaskByIdWithSpecificParent(String email, String parentId, String taskId);
+
+    @Query("MATCH (u:User {email: $email})-->(Task {id: $taskType})-[*1..]->(t:Task) " +
+            "WHERE t.name CONTAINS $text " +
+            "RETURN t")
+    Flux<Task> searchTaskByName(String email, String taskType, String text);
 }


### PR DESCRIPTION
## 한 일
- 문자열 task 검색 기능 추가
- type(root, trash, archive)에 따라 다른 영역에서 검색되게 함
- 만약 type string이 유효하지 않거나, null인 경우 root로 검색 됨
  - e.g. {"text": "오늘"} 와 같이 타입이 명시되지 않은(null) 경우 root로 검색

## 할 일
X

## 장애물
X